### PR TITLE
not update sorting_attribute for closure_table

### DIFF
--- a/lib/active_admin/sortable_tree/controller_actions.rb
+++ b/lib/active_admin/sortable_tree/controller_actions.rb
@@ -33,7 +33,7 @@ module ActiveAdmin::SortableTree
         errors = []
         ActiveRecord::Base.transaction do
           records.each_with_index do |(record, parent_record), position|
-            record.send "#{options[:sorting_attribute]}=", position
+            #record.send "#{options[:sorting_attribute]}=", position
             if options[:tree]
               record.send "#{options[:parent_method]}=", parent_record
             end


### PR DESCRIPTION
closure_tableように一部プログラム修正

sorting_attributeを更新しないように変更